### PR TITLE
Fix Chatbot message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ This project provides a minimal Gradio interface to chat with a local language m
    ```
 
 The LM Studio server URL can be configured with the `LM_STUDIO_URL` environment variable. The default is `http://localhost:1234/v1`.
+
+## Using an OpenAI-compatible endpoint
+
+If you have a chat server that exposes an OpenAI API (for example Ollama), you can run a chat interface in a single line. Make sure the `openai` package is installed and then start the interface with `gr.load_chat`:
+
+```python
+import gradio as gr
+
+gr.load_chat("http://localhost:11434/v1/", model="llama3.2", token="***").launch()
+```

--- a/app.py
+++ b/app.py
@@ -75,7 +75,7 @@ def build_ui() -> gr.Blocks:
                     )
                     refresh_button = gr.Button("🔄 Refresh Models")
             with gr.Column(scale=3):
-                chatbot = gr.Chatbot(label="Chat")
+                chatbot = gr.Chatbot(label="Chat", type="messages")
                 user_message = gr.Textbox(placeholder="Say something", label="Your Message")
 
         state = gr.State([])


### PR DESCRIPTION
## Summary
- fix Chatbot error by using `type="messages"`
- document how to use `gr.load_chat` for OpenAI compatible endpoints

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684239ec5f50832fa041bd80b27b443e