### PR TITLE
Add editing sync and regenerate features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Simple LLM Chat App
 
-This project provides a minimal Gradio interface to chat with a local language model served via LM Studio.
+This project provides a minimal Gradio interface to chat with a local language model served via LM Studio.  
+It now supports message editing, regenerating the last response and several advanced tuning parameters.
 
 ## Setup
 
@@ -17,6 +18,8 @@ This project provides a minimal Gradio interface to chat with a local language m
    ```bash
    python app.py
    ```
+
+While chatting you can edit any message and the conversation state will update automatically. Use the "Regenerate" button to re-run the last user request. The parameter panel exposes temperature, top-p, frequency and presence penalties as well as a seed value for repeatable results.
 
 The LM Studio server URL can be configured with the `LM_STUDIO_URL` environment variable. The default is `http://localhost:1234/v1`.
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,18 @@ def fetch_models() -> list[str]:
         return [f"⚠️ Error fetching models: {exc}"]
 
 
-def generate_chat(user_msg, history, model_id, temperature, max_tokens, system_prompt):
+def generate_chat(
+    user_msg,
+    history,
+    model_id,
+    temperature,
+    max_tokens,
+    system_prompt,
+    top_p,
+    freq_penalty,
+    pres_penalty,
+    seed,
+):
     """Generate a response from the model and update history."""
     if not any(msg.get("role") == "system" for msg in history):
         history.insert(0, {"role": "system", "content": system_prompt})
@@ -34,6 +45,51 @@ def generate_chat(user_msg, history, model_id, temperature, max_tokens, system_p
             messages=history,
             temperature=temperature,
             max_tokens=max_tokens,
+            top_p=top_p,
+            frequency_penalty=freq_penalty,
+            presence_penalty=pres_penalty,
+            seed=seed,
+            stream=False,
+        )
+        assistant_msg = response.choices[0].message.content
+    except Exception as exc:  # noqa: BLE001
+        assistant_msg = f"❌ Error: {exc}"
+
+    history.append({"role": "assistant", "content": assistant_msg})
+    return history, history
+
+
+def regenerate_last(
+    history,
+    model_id,
+    temperature,
+    max_tokens,
+    system_prompt,
+    top_p,
+    freq_penalty,
+    pres_penalty,
+    seed,
+):
+    """Regenerate the assistant's last response."""
+    if not history:
+        return history, history
+
+    if history[-1].get("role") == "assistant":
+        history.pop()
+
+    if not any(msg.get("role") == "system" for msg in history):
+        history.insert(0, {"role": "system", "content": system_prompt})
+
+    try:
+        response = client.chat.completions.create(
+            model=model_id,
+            messages=history,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            frequency_penalty=freq_penalty,
+            presence_penalty=pres_penalty,
+            seed=seed,
             stream=False,
         )
         assistant_msg = response.choices[0].message.content
@@ -54,6 +110,11 @@ def clear_chat():
     return [], []
 
 
+def sync_history(history):
+    """Update internal state after a user edits messages."""
+    return history, history
+
+
 def build_ui() -> gr.Blocks:
     """Construct the Gradio Blocks interface."""
     with gr.Blocks(title="Optimized Local Chat") as demo:
@@ -65,6 +126,10 @@ def build_ui() -> gr.Blocks:
                     model_dropdown = gr.Dropdown(label="Model", choices=fetch_models())
                     temperature_slider = gr.Slider(0.1, 1.5, value=0.7, step=0.1, label="Temperature")
                     max_tokens_slider = gr.Slider(64, 2048, value=512, step=64, label="Max Tokens")
+                    top_p_slider = gr.Slider(0.0, 1.0, value=1.0, step=0.05, label="Top P")
+                    freq_penalty_slider = gr.Slider(-2.0, 2.0, value=0.0, step=0.1, label="Frequency Penalty")
+                    pres_penalty_slider = gr.Slider(-2.0, 2.0, value=0.0, step=0.1, label="Presence Penalty")
+                    seed_number = gr.Number(value=0, precision=0, label="Seed")
                     system_prompt_box = gr.Textbox(
                         label="System Prompt",
                         value="You are a helpful assistant running locally.",
@@ -75,16 +140,44 @@ def build_ui() -> gr.Blocks:
                     )
                     refresh_button = gr.Button("🔄 Refresh Models")
             with gr.Column(scale=3):
-                chatbot = gr.Chatbot(label="Chat", type="messages", resizable=True, editable="all") 
+                chatbot = gr.Chatbot(label="Chat", type="messages", resizable=True, editable="all")
                 user_message = gr.Textbox(placeholder="Say something", label="Your Message", submit_btn="Send")
+                regenerate_button = gr.Button("🔁 Regenerate")
 
         state = gr.State([])
 
         user_message.submit(
             generate_chat,
-            inputs=[user_message, state, model_dropdown, temperature_slider, max_tokens_slider, system_prompt_box],
+            inputs=[
+                user_message,
+                state,
+                model_dropdown,
+                temperature_slider,
+                max_tokens_slider,
+                system_prompt_box,
+                top_p_slider,
+                freq_penalty_slider,
+                pres_penalty_slider,
+                seed_number,
+            ],
             outputs=[chatbot, state],
         )
+        regenerate_button.click(
+            regenerate_last,
+            inputs=[
+                state,
+                model_dropdown,
+                temperature_slider,
+                max_tokens_slider,
+                system_prompt_box,
+                top_p_slider,
+                freq_penalty_slider,
+                pres_penalty_slider,
+                seed_number,
+            ],
+            outputs=[chatbot, state],
+        )
+        chatbot.change(sync_history, chatbot, state)
         refresh_button.click(refresh_models, None, model_dropdown)
         refresh_button.click(clear_chat, None, [chatbot, state])
 


### PR DESCRIPTION
## Summary
- allow message edits to update conversation state
- add regenerate button to rerun last response
- expose advanced OpenAI parameters (top-p, penalties, seed)
- document new capabilities

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68423e499d34832f9c2896b0513c41f6