### PR TITLE
Pin Gradio 4.x and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ It now supports message editing, regenerating the last response and several adva
    ```
 2. **Install dependencies**
    ```bash
-   pip install -r requirements.txt
+   pip install --upgrade "gradio>=4.44.1,<5" -r requirements.txt
    ```
+   This project requires **Gradio 4.x**. The command above installs the latest 4.x release.
 3. **Run the app**
    ```bash
    python app.py

--- a/app.py
+++ b/app.py
@@ -171,6 +171,7 @@ def build_ui() -> gr.Blocks:
                     )
                     refresh_button = gr.Button("🔄 Refresh Models")
             with gr.Column(scale=3):
+                # NOTE: this app expects `type="messages"` (Gradio 4+) for message objects
                 chatbot = gr.Chatbot(
                     label="Chat", type="messages", resizable=True, editable="all"
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gradio
+gradio>=4.44.1,<5
 openai
 httpx


### PR DESCRIPTION
## Summary
- pin gradio to the latest 4.x release
- document that Gradio 4.x is required and show how to upgrade
- add a comment about `type="messages"` in the Chatbot setup

## Testing
- `python -m py_compile app.py`
- `pip install --quiet -r requirements.txt` *(fails: Operation cancelled due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684242f5826c832f8b19265de9fff69d